### PR TITLE
Update Datatype.jl to fix test failures

### DIFF
--- a/test/Datatype.jl
+++ b/test/Datatype.jl
@@ -2,7 +2,7 @@ function test_Datatype()
     @testset "Datatype" begin
         @test Datatype isa Type
 
-        @test openPMD_datatypes isa AbstractVector{<:Type}
+        @test openpmd_datatypes isa AbstractVector{<:Type}
 
         otypes = [CHAR, UCHAR, SHORT, INT, LONG, LONGLONG, USHORT, UINT, ULONG, ULONGLONG, FLOAT, DOUBLE, CFLOAT, CDOUBLE, STRING,
                   VEC_CHAR, VEC_UCHAR, VEC_SHORT, VEC_INT, VEC_LONG, VEC_LONGLONG, VEC_USHORT, VEC_UINT, VEC_ULONG, VEC_ULONGLONG,


### PR DESCRIPTION
Looks like tests are failing on the latest version. The datatype tests expect a variable called `openPMD_datatypes` but the actual variable is called `openpmd_datatypes`. This PR fixes this. I'm not sure if there are other issues holding up the tests, however.